### PR TITLE
Introduce self-hosted Gitea & Codeberg API endpoints

### DIFF
--- a/src/api/v1/forgejo/endpoints/codeberg_redirect.rs
+++ b/src/api/v1/forgejo/endpoints/codeberg_redirect.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use axum::{
+    extract::Path,
+    response::{IntoResponse, Redirect},
+};
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+pub async fn codeberg_redirect(Path(url): Path<String>) -> impl IntoResponse {
+    let target = format!("/v1/forgejo/codeberg.org/{}", url);
+    trace!("target: {target:#?}");
+    Redirect::to(&target).into_response()
+}

--- a/src/api/v1/forgejo/endpoints/get_repo.rs
+++ b/src/api/v1/forgejo/endpoints/get_repo.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Redirect},
+};
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+use super::super::utils::forgejo_api_get_latest_tag_url;
+
+pub async fn get_repo(
+    Path((host, user, repo)): Path<(String, String, String)>,
+    request: Request<Body>,
+) -> impl IntoResponse {
+    if repo.ends_with(".tar.gz") {
+        let latest_tag_url = forgejo_api_get_latest_tag_url(
+            host.clone(),
+            user.clone(),
+            repo.clone()
+                .strip_suffix(".tar.gz")
+                .expect("couldn't strip .tar.gz suffix")
+                .to_string(),
+        )
+        .await
+        .expect("failed to await forgejo_api_get_latest_tag_url");
+        trace!("latest_tag_url: {latest_tag_url:#?}");
+        Redirect::to(&latest_tag_url).into_response()
+    } else {
+        let body = format!(
+            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
+            request.headers()["host"],
+            request.uri()
+        );
+        (StatusCode::BAD_REQUEST, body).into_response()
+    }
+}

--- a/src/api/v1/forgejo/endpoints/get_repo_ref.rs
+++ b/src/api/v1/forgejo/endpoints/get_repo_ref.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Redirect},
+};
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+pub async fn get_repo_ref(
+    Path((host, user, repo, git_ref)): Path<(String, String, String, String)>,
+    request: Request<Body>,
+) -> impl IntoResponse {
+    if git_ref.ends_with(".tar.gz") {
+        let uri = format!(
+            "https://{}/{}/{}/archive/{}.tar.gz",
+            host,
+            user,
+            repo,
+            git_ref
+                .strip_suffix(".tar.gz")
+                .expect("couldn't strip .tar.gz suffix")
+        );
+        Redirect::to(&uri).into_response()
+    } else {
+        let body = format!(
+            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
+            request.headers()["host"],
+            request.uri()
+        );
+        (StatusCode::BAD_REQUEST, body).into_response()
+    }
+}

--- a/src/api/v1/forgejo/endpoints/mod.rs
+++ b/src/api/v1/forgejo/endpoints/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+mod get_repo;
+pub use self::get_repo::get_repo;
+mod get_repo_ref;
+pub use self::get_repo_ref::get_repo_ref;

--- a/src/api/v1/forgejo/endpoints/mod.rs
+++ b/src/api/v1/forgejo/endpoints/mod.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+mod codeberg_redirect;
+pub use self::codeberg_redirect::codeberg_redirect;
 mod get_repo;
 pub use self::get_repo::get_repo;
 mod get_repo_ref;

--- a/src/api/v1/forgejo/mod.rs
+++ b/src/api/v1/forgejo/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pub mod routes;
+
+mod endpoints;
+mod utils;

--- a/src/api/v1/forgejo/routes.rs
+++ b/src/api/v1/forgejo/routes.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::endpoints::{get_repo, get_repo_ref};
+
+use axum::{routing::get, Router};
+
+pub fn get_routes() -> Router {
+    Router::new()
+        .route("/v1/forgejo/:host/:user/:repo/b/:branch", get(get_repo_ref))
+        .route(
+            "/v1/forgejo/:host/:user/:repo/branch/:branch",
+            get(get_repo_ref),
+        )
+        .route(
+            "/v1/forgejo/:host/:user/:repo/v/:version",
+            get(get_repo_ref),
+        )
+        .route(
+            "/v1/forgejo/:host/:user/:repo/version/:version",
+            get(get_repo_ref),
+        )
+        .route(
+            "/v1/forgejo/:host/:user/:repo/t/:version",
+            get(get_repo_ref),
+        )
+        .route(
+            "/v1/forgejo/:host/:user/:repo/tag/:version",
+            get(get_repo_ref),
+        )
+        .route("/v1/forgejo/:host/:user/:repo", get(get_repo))
+}

--- a/src/api/v1/forgejo/routes.rs
+++ b/src/api/v1/forgejo/routes.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::endpoints::{get_repo, get_repo_ref};
+use super::endpoints::{codeberg_redirect, get_repo, get_repo_ref};
 
 use axum::{routing::get, Router};
 
@@ -31,4 +31,5 @@ pub fn get_routes() -> Router {
             get(get_repo_ref),
         )
         .route("/v1/forgejo/:host/:user/:repo", get(get_repo))
+        .route("/v1/codeberg/*req", get(codeberg_redirect))
 }

--- a/src/api/v1/forgejo/utils/forgejo_api_get_latest_tag_url.rs
+++ b/src/api/v1/forgejo/utils/forgejo_api_get_latest_tag_url.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+pub async fn forgejo_api_get_latest_tag_url(
+    host: String,
+    user: String,
+    repo: String,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    use reqwest::{
+        header::{ACCEPT, USER_AGENT},
+        Url,
+    };
+    let version_uri = Url::parse(&format!(
+        "http://{}/api/v1/repos/{}/{}/tags?limit=1",
+        host, user, repo
+    ))?;
+    trace!("version_uri: {version_uri:#?}");
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+    let res = client
+        .get(version_uri)
+        .header(ACCEPT, "application/json")
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+
+    trace!("got:\n {:#?}", res[0]["tarball_url"]);
+
+    Ok(res[0]["tarball_url"]
+        .as_str()
+        .expect("failed to get release tarball_url as_str()")
+        .to_string())
+}

--- a/src/api/v1/forgejo/utils/mod.rs
+++ b/src/api/v1/forgejo/utils/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+mod forgejo_api_get_latest_tag_url;
+pub use self::forgejo_api_get_latest_tag_url::forgejo_api_get_latest_tag_url;

--- a/src/api/v1/mod.rs
+++ b/src/api/v1/mod.rs
@@ -6,4 +6,5 @@
 pub mod routes;
 
 mod flakehub;
+mod forgejo;
 mod github;

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::flakehub::routes::get_routes as get_flakehub_routes;
+use super::forgejo::routes::get_routes as get_forgejo_routes;
 use super::github::routes::get_routes as get_github_routes;
 use axum::Router;
 
@@ -11,4 +12,5 @@ pub fn get_routes() -> Router {
     Router::new()
         .merge(get_github_routes())
         .merge(get_flakehub_routes())
+        .merge(get_forgejo_routes())
 }


### PR DESCRIPTION
This PR has two parts: the first commit introduces the `/v1/gitea/:host/:user/:repo/` family of routes, supporting any self-hosted Gitea or Gitea-compatible forge. The second commit introduces `/v1/codeberg`, a simple redirect to `/v1/gitea/codeberg.org`, 