### PR TITLE
refactor(main): Use nested routing

### DIFF
--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -7,5 +7,5 @@ use super::v1::routes::get_routes as get_v1_routes;
 use axum::Router;
 
 pub fn get_routes() -> Router {
-    Router::new().merge(get_v1_routes())
+    Router::new().nest("/v1", get_v1_routes())
 }

--- a/src/api/v1/flakehub/routes.rs
+++ b/src/api/v1/flakehub/routes.rs
@@ -9,9 +9,6 @@ use axum::{routing::get, Router};
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/v1/flakehub/:user/:repo/v/:version", get(get_repo_version))
-        .route(
-            "/v1/flakehub/:user/:repo/version/:version",
-            get(get_repo_version),
-        )
+        .route("/:user/:repo/v/:version", get(get_repo_version))
+        .route("/:user/:repo/version/:version", get(get_repo_version))
 }

--- a/src/api/v1/forgejo/routes.rs
+++ b/src/api/v1/forgejo/routes.rs
@@ -9,27 +9,15 @@ use axum::{routing::get, Router};
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/v1/forgejo/:host/:user/:repo/b/:branch", get(get_repo_ref))
-        .route(
-            "/v1/forgejo/:host/:user/:repo/branch/:branch",
-            get(get_repo_ref),
-        )
-        .route(
-            "/v1/forgejo/:host/:user/:repo/v/:version",
-            get(get_repo_ref),
-        )
-        .route(
-            "/v1/forgejo/:host/:user/:repo/version/:version",
-            get(get_repo_ref),
-        )
-        .route(
-            "/v1/forgejo/:host/:user/:repo/t/:version",
-            get(get_repo_ref),
-        )
-        .route(
-            "/v1/forgejo/:host/:user/:repo/tag/:version",
-            get(get_repo_ref),
-        )
-        .route("/v1/forgejo/:host/:user/:repo", get(get_repo))
-        .route("/v1/codeberg/*req", get(codeberg_redirect))
+        .route("/:host/:user/:repo/b/:branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/branch/:branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/v/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/version/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/t/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/tag/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo", get(get_repo))
+}
+
+pub fn get_redirect_routes() -> Router {
+    Router::new().route("/codeberg/*req", get(codeberg_redirect))
 }

--- a/src/api/v1/github/endpoints/get_repo.rs
+++ b/src/api/v1/github/endpoints/get_repo.rs
@@ -16,7 +16,7 @@ use log::{debug, error, info, trace, warn};
 use super::super::utils::github_api_get_latest_tag;
 
 pub async fn get_repo(
-    Path((forge, user, repo)): Path<(String, String, String)>,
+    Path((user, repo)): Path<(String, String)>,
     request: Request<Body>,
 ) -> impl IntoResponse {
     if repo.ends_with(".tar.gz") {
@@ -30,8 +30,7 @@ pub async fn get_repo(
         .await
         .expect("failed to await github_api_get_latest_tag");
         let result_uri = format!(
-            "http://{}.com/{}/{}/archive/refs/tags/{}.tar.gz",
-            forge,
+            "http://github.com/{}/{}/archive/refs/tags/{}.tar.gz",
             user,
             repo.strip_suffix(".tar.gz")
                 .expect("couldn't strip .tar.gz suffix"),

--- a/src/api/v1/github/endpoints/get_repo_branch.rs
+++ b/src/api/v1/github/endpoints/get_repo_branch.rs
@@ -14,13 +14,12 @@ use axum::{
 use log::{debug, error, info, trace, warn};
 
 pub async fn get_repo_branch(
-    Path((forge, user, repo, branch)): Path<(String, String, String, String)>,
+    Path((user, repo, branch)): Path<(String, String, String)>,
     request: Request<Body>,
 ) -> impl IntoResponse {
     if branch.ends_with(".tar.gz") {
         let uri = format!(
-            "https://{}.com/{}/{}/archive/refs/heads/{}.tar.gz",
-            forge,
+            "https://github.com/{}/{}/archive/refs/heads/{}.tar.gz",
             user,
             repo,
             branch

--- a/src/api/v1/github/endpoints/get_repo_version.rs
+++ b/src/api/v1/github/endpoints/get_repo_version.rs
@@ -14,13 +14,12 @@ use axum::{
 use log::{debug, error, info, trace, warn};
 
 pub async fn get_repo_version(
-    Path((forge, user, repo, version)): Path<(String, String, String, String)>,
+    Path((user, repo, version)): Path<(String, String, String)>,
     request: Request<Body>,
 ) -> impl IntoResponse {
     if version.ends_with(".tar.gz") {
         let uri = format!(
-            "https://{}.com/{}/{}/archive/refs/tags/{}.tar.gz",
-            forge,
+            "https://github.com/{}/{}/archive/refs/tags/{}.tar.gz",
             user,
             repo,
             version

--- a/src/api/v1/github/routes.rs
+++ b/src/api/v1/github/routes.rs
@@ -9,17 +9,11 @@ use axum::{routing::get, Router};
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/v1/:forge/:user/:repo/b/:branch", get(get_repo_branch))
-        .route(
-            "/v1/:forge/:user/:repo/branch/:branch",
-            get(get_repo_branch),
-        )
-        .route("/v1/:forge/:user/:repo/v/:version", get(get_repo_version))
-        .route(
-            "/v1/:forge/:user/:repo/version/:version",
-            get(get_repo_version),
-        )
-        .route("/v1/:forge/:user/:repo/t/:version", get(get_repo_version))
-        .route("/v1/:forge/:user/:repo/tag/:version", get(get_repo_version))
-        .route("/v1/:forge/:user/:repo", get(get_repo))
+        .route("/:user/:repo/b/:branch", get(get_repo_branch))
+        .route("/:user/:repo/branch/:branch", get(get_repo_branch))
+        .route("/:user/:repo/v/:version", get(get_repo_version))
+        .route("/:user/:repo/version/:version", get(get_repo_version))
+        .route("/:user/:repo/t/:version", get(get_repo_version))
+        .route("/:user/:repo/tag/:version", get(get_repo_version))
+        .route("/:user/:repo", get(get_repo))
 }

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -14,5 +14,6 @@ pub fn get_routes() -> Router {
         .nest("/github", get_github_routes())
         .nest("/flakehub", get_flakehub_routes())
         .nest("/forgejo", get_forgejo_routes())
+        .nest("/gitea", get_forgejo_routes())
         .merge(get_forgejo_redirect_routes())
 }

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -4,13 +4,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::flakehub::routes::get_routes as get_flakehub_routes;
+use super::forgejo::routes::get_redirect_routes as get_forgejo_redirect_routes;
 use super::forgejo::routes::get_routes as get_forgejo_routes;
 use super::github::routes::get_routes as get_github_routes;
 use axum::Router;
 
 pub fn get_routes() -> Router {
     Router::new()
-        .merge(get_github_routes())
-        .merge(get_flakehub_routes())
-        .merge(get_forgejo_routes())
+        .nest("/github", get_github_routes())
+        .nest("/flakehub", get_flakehub_routes())
+        .nest("/forgejo", get_forgejo_routes())
+        .merge(get_forgejo_redirect_routes())
 }


### PR DESCRIPTION
Rather than repeating the route prefixes, use nested routing. This does require splitting out the Codeberg redirect from the rest of the Forgejo routes, but that's not necessarily a bad thing. (Implemented in be9eb85cc88179c34568c0743900e07d219108e5)

The topmost commit (42548aa80da694158887f9e5f7b3aa7a5d4003fd) adds a `/v1/gitea` route, handled by the same code as `/v1/forgejo`, without a redirect.

Builds on top of #2.