### PR TITLE
feat(gitlab): Introduce a self-hosted gitlab endpoint

### DIFF
--- a/src/api/v1/gitlab/endpoints/get_repo.rs
+++ b/src/api/v1/gitlab/endpoints/get_repo.rs
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Redirect},
+};
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+use super::super::utils::gitlab_api_get_latest_tag;
+
+pub async fn get_repo(
+    Path((host, user, repo)): Path<(String, String, String)>,
+    request: Request<Body>,
+) -> impl IntoResponse {
+    if repo.ends_with(".tar.gz") {
+        let tag = gitlab_api_get_latest_tag(
+            host.clone(),
+            user.clone(),
+            repo.clone()
+                .strip_suffix(".tar.gz")
+                .expect("couldn't strip .tar.gz suffix")
+                .to_string(),
+        )
+        .await
+        .expect("failed to await gitlab_api_get_latest_tag");
+        let result_uri = format!(
+            "/v1/gitlab/{}/{}/{}/v/{}.tar.gz",
+            host,
+            user,
+            repo.strip_suffix(".tar.gz")
+                .expect("couldn't strip .tar.gz suffix"),
+            tag,
+        );
+        trace!("{result_uri:#?}");
+        Redirect::to(&result_uri).into_response()
+    } else {
+        let body = format!(
+            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
+            request.headers()["host"],
+            request.uri()
+        );
+        (StatusCode::BAD_REQUEST, body).into_response()
+    }
+}

--- a/src/api/v1/gitlab/endpoints/get_repo_ref.rs
+++ b/src/api/v1/gitlab/endpoints/get_repo_ref.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Redirect},
+};
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+pub async fn get_repo_ref(
+    Path((host, user, repo, git_ref)): Path<(String, String, String, String)>,
+    request: Request<Body>,
+) -> impl IntoResponse {
+    if git_ref.ends_with(".tar.gz") {
+        let git_ref_name = git_ref
+            .strip_suffix(".tar.gz")
+            .expect("couldn't strip .tar.gz suffix");
+        let uri = format!(
+            "https://{}/{}/{}/-/archive/{}/{}-{}.tar.gz",
+            host, user, repo, git_ref_name, repo, git_ref_name,
+        );
+        Redirect::to(&uri).into_response()
+    } else {
+        let body = format!(
+            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
+            request.headers()["host"],
+            request.uri()
+        );
+        (StatusCode::BAD_REQUEST, body).into_response()
+    }
+}

--- a/src/api/v1/gitlab/endpoints/mod.rs
+++ b/src/api/v1/gitlab/endpoints/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+mod get_repo;
+pub use self::get_repo::get_repo;
+mod get_repo_ref;
+pub use self::get_repo_ref::get_repo_ref;

--- a/src/api/v1/gitlab/mod.rs
+++ b/src/api/v1/gitlab/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pub mod routes;
+
+mod endpoints;
+mod utils;

--- a/src/api/v1/gitlab/routes.rs
+++ b/src/api/v1/gitlab/routes.rs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::endpoints::{get_repo, get_repo_ref};
+
+use axum::{routing::get, Router};
+
+pub fn get_routes() -> Router {
+    Router::new()
+        .route("/:host/:user/:repo/b/:branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/branch/:branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/v/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/version/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/t/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/tag/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo", get(get_repo))
+}

--- a/src/api/v1/gitlab/utils/gitlab_api_get_latest_tag.rs
+++ b/src/api/v1/gitlab/utils/gitlab_api_get_latest_tag.rs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+pub async fn gitlab_api_get_latest_tag(
+    host: String,
+    user: String,
+    repo: String,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    use reqwest::{
+        header::{ACCEPT, USER_AGENT},
+        Url,
+    };
+    // TODO: The middle part, `{}%2F{}` is really `user/repo` URL-encoded. We
+    // should do proper URL encoding.
+    let version_uri = Url::parse(&format!(
+        "https://{}/api/v4/projects/{}%2F{}/repository/tags",
+        host, user, repo
+    ))?;
+    trace!("{:#?}", version_uri);
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
+    let res = client
+        .get(version_uri)
+        .header(ACCEPT, "application/json")
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+
+    trace!("got:\n {:#?}", res[0]["name"]);
+
+    Ok(res[0]["name"]
+        .as_str()
+        .expect("failed to get release name as_str()")
+        .to_string())
+}

--- a/src/api/v1/gitlab/utils/mod.rs
+++ b/src/api/v1/gitlab/utils/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Gergely Nagy
+// SPDX-FileContributor: Gergely Nagy
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+mod gitlab_api_get_latest_tag;
+pub use self::gitlab_api_get_latest_tag::gitlab_api_get_latest_tag;

--- a/src/api/v1/mod.rs
+++ b/src/api/v1/mod.rs
@@ -8,3 +8,4 @@ pub mod routes;
 mod flakehub;
 mod forgejo;
 mod github;
+mod gitlab;

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -7,6 +7,7 @@ use super::flakehub::routes::get_routes as get_flakehub_routes;
 use super::forgejo::routes::get_redirect_routes as get_forgejo_redirect_routes;
 use super::forgejo::routes::get_routes as get_forgejo_routes;
 use super::github::routes::get_routes as get_github_routes;
+use super::gitlab::routes::get_routes as get_gitlab_routes;
 use axum::Router;
 
 pub fn get_routes() -> Router {
@@ -15,5 +16,6 @@ pub fn get_routes() -> Router {
         .nest("/flakehub", get_flakehub_routes())
         .nest("/forgejo", get_forgejo_routes())
         .nest("/gitea", get_forgejo_routes())
+        .nest("/gitlab", get_gitlab_routes())
         .merge(get_forgejo_redirect_routes())
 }


### PR DESCRIPTION
This introduces the `/v1/gitlab/:host/:user/:repo` routes, where `:host` is any GitLab instance (including, possibly, gitlab.com).

I have not made `gitlab.com` the default, because that seems to require a login to do anything at all, at least on the web UI side of things, and I couldn't be bothered to look further. I did some testing with `gitlab.gnome.org` and `salsa.debian.org`, and things seem to work well.

I even found a flake-enabled project on salsa: `nix run 'http://127.0.0.1:3000/v1/gitlab/salsa.debian.org/reproducible-builds/reproducible-website/b/master.tar.gz'` does... uhh... something? Not sure what it is supposed to do, but the flake gets evaluated. Sadly, there is no release with a flake yet, so can't directly test that.

But I did test that looking up the latest tag works! However, there's a small TODO item there, part of the URL needs to be URL-encoded, and the code in this PR doesn't do that properly. It url-encodes the `/` part of `user/repo`, but if `user` or `repo` would require encoding too, things might break. That is, imo, such an unlikely scenario that I didn't bother with proper encoding.

If proper encoding is required, rime will need to depend on something like `form_urlencode` directly.