### PR TITLE
fix(darwin): add SystemConfiguration, refactor slightly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,10 @@
         };
 
         treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
-        buildInputs = with pkgs; [pkg-config openssl] ++ lib.optionals stdenv.isDarwin [libiconv darwin.apple_sdk.frameworks.Security];
+
+        darwinBuildInputs = with pkgs; with darwin.apple_sdk.frameworks; [libiconv Security SystemConfiguration];
+
+        buildInputs = with pkgs; [pkg-config openssl] ++ lib.optionals stdenv.isDarwin darwinBuildInputs;
       in rec {
         # For `nix fmt`
         formatter = treefmtEval.config.build.wrapper;


### PR DESCRIPTION
This adds `SystemConfiguration` from the apple sdk frameworks, in the hopes of
resolving #16.

This also refactors out darwinBuildInputs into a list of packages, mostly to
keep lines from being too long.

As I don't currently have access to a MacOS box, I can't verify this.
Potentially setting up Nix aware CI might be an option for later.

Closes: #16
