### PR TITLE
bug(api): handle branch names with slashes in them

### DIFF
--- a/justfile
+++ b/justfile
@@ -214,6 +214,12 @@ itest:
     just run_test "http://localhost:3000/v1/next.forgejo.org/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/flakehub.com/cafkafk/hello/v/v0.0.1.tar.gz"
 
+    just run_test "http://localhost:3000/v1/codeberg/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
+    just run_test "http://localhost:3000/v1/github/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
+    just run_test "http://localhost:3000/v1/gitlab/gitlab.com/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
+    just run_test "http://localhost:3000/v1/forgejo/next.forgejo.org/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
+    just run_test "http://localhost:3000/v1/git.madhouse-project.org/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
+
     @echo "tests passsed :3"
 
 # Integration Testing of rime.cx (requires Nix)
@@ -231,5 +237,7 @@ itest-live:
     just run_test "http://rime.cx/v1/gitlab.com/cafkafk/hello.tar.gz"
     just run_test "http://rime.cx/v1/next.forgejo.org/cafkafk/hello.tar.gz"
     just run_test "http://rime.cx/v1/flakehub.com/cafkafk/hello/v/v0.0.1.tar.gz"
+
+    just run_test "http://rime.cx/v1/git.madhouse-project.org/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
 
     @echo "tests passsed :3"

--- a/src/api/v1/forgejo/routes.rs
+++ b/src/api/v1/forgejo/routes.rs
@@ -9,8 +9,8 @@ use axum::{routing::get, Router};
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/:host/:user/:repo/b/:branch", get(get_repo_ref))
-        .route("/:host/:user/:repo/branch/:branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/b/*branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/branch/*branch", get(get_repo_ref))
         .route("/:host/:user/:repo/v/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/version/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/t/:version", get(get_repo_ref))

--- a/src/api/v1/github/routes.rs
+++ b/src/api/v1/github/routes.rs
@@ -9,8 +9,8 @@ use axum::{routing::get, Router};
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/:user/:repo/b/:branch", get(get_repo_branch))
-        .route("/:user/:repo/branch/:branch", get(get_repo_branch))
+        .route("/:user/:repo/b/*branch", get(get_repo_branch))
+        .route("/:user/:repo/branch/*branch", get(get_repo_branch))
         .route("/:user/:repo/v/:version", get(get_repo_version))
         .route("/:user/:repo/version/:version", get(get_repo_version))
         .route("/:user/:repo/t/:version", get(get_repo_version))

--- a/src/api/v1/gitlab/endpoints/get_repo_ref.rs
+++ b/src/api/v1/gitlab/endpoints/get_repo_ref.rs
@@ -21,9 +21,10 @@ pub async fn get_repo_ref(
         let git_ref_name = git_ref
             .strip_suffix(".tar.gz")
             .expect("couldn't strip .tar.gz suffix");
+        let git_ref_dashed_name = git_ref_name.replace('/', "-");
         let uri = format!(
             "https://{}/{}/{}/-/archive/{}/{}-{}.tar.gz",
-            host, user, repo, git_ref_name, repo, git_ref_name,
+            host, user, repo, git_ref_name, repo, git_ref_dashed_name,
         );
         Redirect::to(&uri).into_response()
     } else {

--- a/src/api/v1/gitlab/routes.rs
+++ b/src/api/v1/gitlab/routes.rs
@@ -9,8 +9,8 @@ use axum::{routing::get, Router};
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/:host/:user/:repo/b/:branch", get(get_repo_ref))
-        .route("/:host/:user/:repo/branch/:branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/b/*branch", get(get_repo_ref))
+        .route("/:host/:user/:repo/branch/*branch", get(get_repo_ref))
         .route("/:host/:user/:repo/v/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/version/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/t/:version", get(get_repo_ref))

--- a/src/api/v1/sourcehut/routes.rs
+++ b/src/api/v1/sourcehut/routes.rs
@@ -9,8 +9,8 @@ use super::endpoints::get_repo_ref;
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/:host/:user/:repo/b/:version", get(get_repo_ref))
-        .route("/:host/:user/:repo/branch/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/b/*version", get(get_repo_ref))
+        .route("/:host/:user/:repo/branch/*version", get(get_repo_ref))
         .route("/:host/:user/:repo/v/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/version/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/t/:version", get(get_repo_ref))


### PR DESCRIPTION
When dealing with branches, don't capture just one slice of the path as the branch name, but every part of the path from that point on. This lets us easily deal with branches that have slashes in their names.

Since the branch is always the last part of the URI, and the `/b/` or `/branch/` part routes things here anyway, capturing the rest of the path is safe. Only the path is captured, query strings are not, those aren't part of the routing.

Fixes #19.