### PR TITLE
feat(sourcehut): add sourcehut, git.sr.ht

### DIFF
--- a/justfile
+++ b/justfile
@@ -200,6 +200,9 @@ itest:
     just run_test "http://localhost:3000/v1/flakehub/cafkafk/hello/v/v0.0.1.tar.gz"
     just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/v/v0.0.1.tar.gz"
 
+    # Branch Endpoints
+    just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/b/main.tar.gz"
+
     # Tags Endpoints
     just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/t/v0.0.1.tar.gz"
     just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/t/main.tar.gz"

--- a/justfile
+++ b/justfile
@@ -190,14 +190,21 @@ run_test TARGET:
 itest:
     # TODO: self hosted gitlab
 
+    # Default Endpoints
     just run_test "http://localhost:3000/v1/codeberg/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/github/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/gitlab/gitlab.com/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/forgejo/next.forgejo.org/cafkafk/hello.tar.gz"
-    just run_test "http://localhost:3000/v1/flakehub/cafkafk/hello/v/v0.0.1.tar.gz"
 
+    # Version Endpoints
+    just run_test "http://localhost:3000/v1/flakehub/cafkafk/hello/v/v0.0.1.tar.gz"
     just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/v/v0.0.1.tar.gz"
 
+    # Tags Endpoints
+    just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/t/v0.0.1.tar.gz"
+    just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/t/main.tar.gz"
+
+    # Autodiscovery
     just run_test "http://localhost:3000/v1/codeberg.org/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/github.com/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/gitlab.com/cafkafk/hello.tar.gz"

--- a/justfile
+++ b/justfile
@@ -196,6 +196,8 @@ itest:
     just run_test "http://localhost:3000/v1/forgejo/next.forgejo.org/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/flakehub/cafkafk/hello/v/v0.0.1.tar.gz"
 
+    just run_test "http://localhost:3000/v1/sourcehut/git.sr.ht/cafkafk/hello/v/v0.0.1.tar.gz"
+
     just run_test "http://localhost:3000/v1/codeberg.org/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/github.com/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/gitlab.com/cafkafk/hello.tar.gz"

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -3,13 +3,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use axum::Router;
+
 use super::auto_discovery::routes::get_routes as get_auto_discovery_routes;
 use super::flakehub::routes::get_routes as get_flakehub_routes;
 use super::forgejo::routes::get_redirect_routes as get_forgejo_redirect_routes;
 use super::forgejo::routes::get_routes as get_forgejo_routes;
 use super::github::routes::get_routes as get_github_routes;
 use super::gitlab::routes::get_routes as get_gitlab_routes;
-use axum::Router;
+use super::sourcehut::routes::get_routes as get_sourcehut_routes;
 
 pub fn get_routes() -> Router {
     Router::new()
@@ -21,5 +23,6 @@ pub fn get_routes() -> Router {
         .nest("/forgejo", get_forgejo_routes())
         .nest("/gitea", get_forgejo_routes())
         .nest("/gitlab", get_gitlab_routes())
+        .nest("/sourcehut", get_sourcehut_routes())
         .merge(get_forgejo_redirect_routes())
 }

--- a/src/api/v1/sourcehut/endpoints/get_repo_ref.rs
+++ b/src/api/v1/sourcehut/endpoints/get_repo_ref.rs
@@ -13,13 +13,12 @@ use axum::{
 #[allow(unused)]
 use log::{debug, error, info, trace, warn};
 
-pub async fn get_repo_version(
-    Path((host, user, repo, version)): Path<(String, String, String, String)>,
+pub async fn get_repo_ref(
+    Path((host, user, repo, git_ref)): Path<(String, String, String, String)>,
     request: Request<Body>,
 ) -> impl IntoResponse {
-    if version.ends_with(".tar.gz") {
-        let uri = format!("https://{}/~{}/{}/archive/{}", host, user, repo, version);
-        debug!("sourcehut: get_repo_version uri {uri:#?}");
+    if git_ref.ends_with(".tar.gz") {
+        let uri = format!("https://{}/~{}/{}/archive/{}", host, user, repo, git_ref);
         Redirect::to(&uri).into_response()
     } else {
         let body = format!(

--- a/src/api/v1/sourcehut/endpoints/get_repo_version.rs
+++ b/src/api/v1/sourcehut/endpoints/get_repo_version.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Christina Sørensen
+// SPDX-FileContributor: Christina Sørensen
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{Request, StatusCode},
+    response::{IntoResponse, Redirect},
+};
+
+#[allow(unused)]
+use log::{debug, error, info, trace, warn};
+
+pub async fn get_repo_version(
+    Path((host, user, repo, version)): Path<(String, String, String, String)>,
+    request: Request<Body>,
+) -> impl IntoResponse {
+    if version.ends_with(".tar.gz") {
+        let uri = format!("https://{}/~{}/{}/archive/{}", host, user, repo, version);
+        debug!("sourcehut: get_repo_version uri {uri:#?}");
+        Redirect::to(&uri).into_response()
+    } else {
+        let body = format!(
+            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
+            request.headers()["host"],
+            request.uri()
+        );
+        (StatusCode::BAD_REQUEST, body).into_response()
+    }
+}

--- a/src/api/v1/sourcehut/endpoints/mod.rs
+++ b/src/api/v1/sourcehut/endpoints/mod.rs
@@ -3,5 +3,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-mod get_repo_version;
-pub use self::get_repo_version::get_repo_version;
+mod get_repo_ref;
+
+pub use self::get_repo_ref::get_repo_ref;

--- a/src/api/v1/sourcehut/endpoints/mod.rs
+++ b/src/api/v1/sourcehut/endpoints/mod.rs
@@ -3,11 +3,5 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pub mod routes;
-
-mod auto_discovery;
-mod flakehub;
-mod forgejo;
-mod github;
-mod gitlab;
-mod sourcehut;
+mod get_repo_version;
+pub use self::get_repo_version::get_repo_version;

--- a/src/api/v1/sourcehut/mod.rs
+++ b/src/api/v1/sourcehut/mod.rs
@@ -5,9 +5,4 @@
 
 pub mod routes;
 
-mod auto_discovery;
-mod flakehub;
-mod forgejo;
-mod github;
-mod gitlab;
-mod sourcehut;
+mod endpoints;

--- a/src/api/v1/sourcehut/routes.rs
+++ b/src/api/v1/sourcehut/routes.rs
@@ -3,12 +3,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use super::endpoints::get_repo_version;
-
 use axum::{routing::get, Router};
+
+use super::endpoints::get_repo_ref;
 
 pub fn get_routes() -> Router {
     Router::new()
-        .route("/:host/:user/:repo/v/:version", get(get_repo_version))
-        .route("/:host/:user/:repo/version/:version", get(get_repo_version))
+        .route("/:host/:user/:repo/v/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/version/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/t/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/tag/:version", get(get_repo_ref))
 }

--- a/src/api/v1/sourcehut/routes.rs
+++ b/src/api/v1/sourcehut/routes.rs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2023 Christina Sørensen
+// SPDX-FileContributor: Christina Sørensen
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use super::endpoints::get_repo_version;
+
+use axum::{routing::get, Router};
+
+pub fn get_routes() -> Router {
+    Router::new()
+        .route("/:host/:user/:repo/v/:version", get(get_repo_version))
+        .route("/:host/:user/:repo/version/:version", get(get_repo_version))
+}

--- a/src/api/v1/sourcehut/routes.rs
+++ b/src/api/v1/sourcehut/routes.rs
@@ -9,6 +9,8 @@ use super::endpoints::get_repo_ref;
 
 pub fn get_routes() -> Router {
     Router::new()
+        .route("/:host/:user/:repo/b/:version", get(get_repo_ref))
+        .route("/:host/:user/:repo/branch/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/v/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/version/:version", get(get_repo_ref))
         .route("/:host/:user/:repo/t/:version", get(get_repo_ref))


### PR DESCRIPTION
This adds a simple sourcehut endpoint for versioned tarballs. It also
includes tests for this new endpoint.

This was tested against integration tests, as well as `nix flake check`.

Refs: #14

Signed-off-by: Christina Sørensen <christina@cafkafk.com>

(More commits following this)
