### PR TITLE
bug(cli): Gracefully handle partial configs

### DIFF
--- a/src/data/config.rs
+++ b/src/data/config.rs
@@ -20,10 +20,10 @@ const PORT: &str = "3000";
 pub struct Config {
     /// The address of the server
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub addr: Option<String>,
+    addr: Option<String>,
     /// The port of the server
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub port: Option<String>,
+    port: Option<String>,
 }
 
 impl Config {
@@ -49,6 +49,20 @@ impl Config {
             },
         }
     }
+    pub fn bind_addr(&self) -> std::net::SocketAddr {
+        let socket_addr: String = format!(
+            "{}:{}",
+            self.addr.clone().unwrap_or(ADDR.to_string()),
+            self.port.clone().unwrap_or(PORT.to_string())
+        );
+
+        debug!("socket_addr: {socket_addr:#?}");
+
+        socket_addr
+            .parse()
+            .expect("failed to parse the bind address")
+    }
+
     pub fn _gen_example_config(&self) -> Result<(), Error> {
         let data = serde_yaml::to_string(&self).expect("failed to deserialize self to yaml");
         write(CONFIG, data)

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,14 +35,6 @@ async fn main() {
 
     trace!("{config:#?}");
 
-    let socket_addr: String = format!(
-        "{}:{}",
-        config.addr.expect("couldn't unwrap config.addr"),
-        config.port.expect("couldn't unwrap config.addr")
-    );
-
-    debug!("{socket_addr:#?}");
-
     let app = Router::new()
         .route(
             "/",
@@ -50,7 +42,7 @@ async fn main() {
         )
         .merge(get_api_routes());
 
-    axum::Server::bind(&socket_addr.parse().expect("failed to parse socket_addr"))
+    axum::Server::bind(&config.bind_addr())
         .serve(app.into_make_service())
         .await
         .expect("failed to await on bind().serve()");


### PR DESCRIPTION
If the configuration file read only contains partial configuration, gracefully fall back to default values for settings that were not specified.

This is achieved by not accessing the settings directly, but through a wrapper that can handle the necessary fallback. To enforce that, the struct members are no longer public.

Fixes #26.