### PR TITLE
bug(api): Fix Forgejo & GitLab latest tag APIs

### DIFF
--- a/src/api/v1/forgejo/utils/forgejo_api_get_latest_tag_url.rs
+++ b/src/api/v1/forgejo/utils/forgejo_api_get_latest_tag_url.rs
@@ -16,7 +16,7 @@ pub async fn forgejo_api_get_latest_tag_url(
         Url,
     };
     let version_uri = Url::parse(&format!(
-        "http://{}/api/v1/repos/{}/{}/tags?limit=1",
+        "http://{}/api/v1/repos/{}/{}/releases?limit=1",
         host, user, repo
     ))?;
     trace!("version_uri: {version_uri:#?}");

--- a/src/api/v1/gitlab/utils/gitlab_api_get_latest_tag.rs
+++ b/src/api/v1/gitlab/utils/gitlab_api_get_latest_tag.rs
@@ -18,7 +18,7 @@ pub async fn gitlab_api_get_latest_tag(
     // TODO: The middle part, `{}%2F{}` is really `user/repo` URL-encoded. We
     // should do proper URL encoding.
     let version_uri = Url::parse(&format!(
-        "https://{}/api/v4/projects/{}%2F{}/repository/tags",
+        "https://{}/api/v4/projects/{}%2F{}/releases",
         host, user, repo
     ))?;
     trace!("{:#?}", version_uri);
@@ -31,9 +31,9 @@ pub async fn gitlab_api_get_latest_tag(
         .json::<serde_json::Value>()
         .await?;
 
-    trace!("got:\n {:#?}", res[0]["name"]);
+    trace!("got:\n {:#?}", res[0]["tag_name"]);
 
-    Ok(res[0]["name"]
+    Ok(res[0]["tag_name"]
         .as_str()
         .expect("failed to get release name as_str()")
         .to_string())


### PR DESCRIPTION
Rather than grabbing the latest tag, both Forgejo and GitLab should do the same thing the GitHub module does: grab the latest tag belonging to a release.

The latest tag is not necessarily a *release*, and should not be treated as such.

Fixes #25.