### PR TITLE
feat(semver): Semver locking API endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "pretty_env_logger",
  "regex",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1079,6 +1080,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4.20"
 pretty_env_logger = "0.5.0"
 regex = "1.10.2"
 reqwest = { version = "0.11.22", features = ["cookies", "json"] }
+semver = "1.0.20"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9.27"

--- a/justfile
+++ b/justfile
@@ -249,6 +249,12 @@ itest:
     just run_test "http://localhost:3000/v1/forgejo/next.forgejo.org/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
     just run_test "http://localhost:3000/v1/git.madhouse-project.org/cafkafk/hello/b/a-/t/e/s/t/i/n/g/b/r/a/n/c/h-th@t-should-be-/ha/rd/to/d/e/a/l/wi/th.tar.gz"
 
+    # Test semantic versioning
+    just run_test "http://localhost:3000/v1/github/cafkafk/hello/s/*.tar.gz"
+    just run_test_pre "http://localhost:3000/v1/github/cafkafk/hello/s/0.0.2-pre.1.tar.gz"
+    # ?version=>=0.0.1,<=0.0.2-pre.5
+    just run_test_pre "http://localhost:3000/v1/github/cafkafk/hello/s/*.tar.gz?version=%3e%3d0.0.1%2c%3c%3d0.0.2-pre.5"
+
     @echo "tests passsed :3"
 
 # Integration Testing of rime.cx (requires Nix)

--- a/src/api/v1/forge/error.rs
+++ b/src/api/v1/forge/error.rs
@@ -17,6 +17,7 @@ pub enum ForgeError {
     EndpointUnavailable,
     NoFlagshipInstance,
     AutodetectFailed(String),
+    SemverError(semver::Error),
 }
 
 impl IntoResponse for ForgeError {
@@ -50,6 +51,10 @@ impl IntoResponse for ForgeError {
                     format!("failed to auto-detect the forge on {}", host),
                 )
             }
+            ForgeError::SemverError(error) => {
+                error!("ForgeError::SemverError: {error}");
+                (StatusCode::BAD_REQUEST, error.to_string())
+            }
         };
         (status, error_message).into_response()
     }
@@ -58,5 +63,11 @@ impl IntoResponse for ForgeError {
 impl From<reqwest::Error> for ForgeError {
     fn from(error: reqwest::Error) -> ForgeError {
         ForgeError::RequestError(error)
+    }
+}
+
+impl From<semver::Error> for ForgeError {
+    fn from(error: semver::Error) -> ForgeError {
+        ForgeError::SemverError(error)
     }
 }

--- a/src/api/v1/forge/error.rs
+++ b/src/api/v1/forge/error.rs
@@ -18,6 +18,7 @@ pub enum ForgeError {
     NoFlagshipInstance,
     AutodetectFailed(String),
     SemverError(semver::Error),
+    BadRequest(String),
 }
 
 impl IntoResponse for ForgeError {
@@ -54,6 +55,10 @@ impl IntoResponse for ForgeError {
             ForgeError::SemverError(error) => {
                 error!("ForgeError::SemverError: {error}");
                 (StatusCode::BAD_REQUEST, error.to_string())
+            }
+            ForgeError::BadRequest(error) => {
+                error!("ForgeError::BadRequest: {error}");
+                (StatusCode::BAD_REQUEST, error)
             }
         };
         (status, error_message).into_response()

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -41,6 +41,14 @@ fn get_forge_routes(forge: impl Forge + Send + Sync + 'static) -> Router {
             "/:user/:repo/t/:version",
             get(forge::handlers::get_tarball_url_for_version),
         )
+        .route(
+            "/:user/:repo/semver/:version",
+            get(forge::handlers::get_tarball_url_for_semantic_version),
+        )
+        .route(
+            "/:user/:repo/s/:version",
+            get(forge::handlers::get_tarball_url_for_semantic_version),
+        )
         .layer(Extension(forge))
 }
 


### PR DESCRIPTION
I'm sorry, this is another stacked pull request, built on top of #30 this time. The gist of it is in c732f4e29ccdbc4755bbf5857905b0e5461cecd9, and the commit message explains it well enough, I believe:

---
This adds a new `/semver/:version` (and `/s/:version`) route to all forges that implement release listing. The specified version is parsed as a semver version requirement (more about that here[^1]), and releases for the given repo are matched against it.

The matching is done by comparing the sanitized tag name: if the tag begins with `v`, that character is stripped, and the rest is parsed as a semantic version string; if the tag begins with the repo name and a dash (another common pattern in tagging), then the `{repo}-` prefix is removed, and the rest is parsed as a semantic version string; if neither case applies, we try to parse the tag name as a semantic version as is.

If we can't parse the sanitized tag name as a semantic version, then we consider it non-matching. Otherwise it is compared to the given version requirement.

This allows many forms of version requirement specifications, but is limited. Another way will be added later that allows specifying more complex ranges in the query string.

 [^1]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html

Fixes #10.

---

The second patch (63dd1881d1615dcfd0287a8a23b9bc307773ee95) adds the query string method too. Same endpoint, but if there's a `?version=spec` query string, that will override the path.

With these two combined, we can do stuff like this:

```
❯ PROJECT="forgejo/git.madhouse-project.org/algernon/rime-testing"
❯ RIME="http://127.0.0.1:3000/v1"
❯ curl -i "${RIME}/${PROJECT}/semver/*.tar.gz"
location: https://.../algernon/rime-testing/archive/2.0.2.tar.gz
❯ curl -i "${RIME}/${PROJECT}/semver/=2.0.1-alpha.1.tar.gz"
location: https://.../algernon/rime-testing/archive/2.0.1-alpha.1.tar.gz
❯ curl -i "${RIME}/${PROJECT}/semver/2.0.1-alpha.1.tar.gz"
location: https://.../algernon/rime-testing/archive/2.0.2.tar.gz
❯ curl -i "${RIME}/${PROJECT}/semver/*.tar.gz" --url-query version=">=1.0,<2.0"
location: https://.../algernon/rime-testing/archive/1.2.3.tar.gz
```

I opted to build this on top of #30, because otherwise there would have been tremendous amounts of code duplication. There's still more than I'd like, but *considerably* less than it would've been otherwise.