### PR TITLE
refactor(routes): Lift routing out of the Forge trait

### DIFF
--- a/src/api/v1/forge.rs
+++ b/src/api/v1/forge.rs
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use axum::{async_trait, extract::Extension, routing::get, Router};
+use axum::async_trait;
 use std::sync::Arc;
 
 #[allow(unused)]
@@ -12,7 +12,7 @@ use log::{debug, error, info, trace, warn};
 
 mod error;
 pub use error::ForgeError;
-mod handlers;
+pub mod handlers;
 mod releases;
 pub use releases::ForgeReleases;
 
@@ -49,52 +49,6 @@ pub trait Forge {
     ) -> Result<String, ForgeError>;
 
     async fn get_repo_url(&self, host: &str, user: &str, repo: &str) -> Result<String, ForgeError>;
-
-    // The functions below come with reasonable defaults. In most cases, structs
-    // implementing the trait will not need to override them.
-
-    fn get_routes(&self) -> Router
-    where
-        Self: Sized + Send + Sync + 'static,
-    {
-        Router::new()
-            .route(
-                "/:user/:repo",
-                get(handlers::get_tarball_url_for_latest_release),
-            )
-            .route(
-                "/:user/:repo/branch/*branch",
-                get(handlers::get_tarball_url_for_branch),
-            )
-            .route(
-                "/:user/:repo/b/*branch",
-                get(handlers::get_tarball_url_for_branch),
-            )
-            .route(
-                "/:user/:repo/version/:version",
-                get(handlers::get_tarball_url_for_version),
-            )
-            .route(
-                "/:user/:repo/v/:version",
-                get(handlers::get_tarball_url_for_version),
-            )
-            .route(
-                "/:user/:repo/tag/:version",
-                get(handlers::get_tarball_url_for_version),
-            )
-            .route(
-                "/:user/:repo/t/:version",
-                get(handlers::get_tarball_url_for_version),
-            )
-            .layer(Extension(Arc::new(Self::new()) as DynForge))
-    }
-
-    fn get_self_hosted_routes(&self) -> Router
-    where
-        Self: Sized + Send + Sync + 'static,
-    {
-        Router::new().nest("/:host", self.get_routes())
-    }
 }
 
 pub type DynForge = Arc<dyn Forge + Send + Sync>;

--- a/src/api/v1/forge.rs
+++ b/src/api/v1/forge.rs
@@ -18,10 +18,6 @@ pub use releases::ForgeReleases;
 
 #[async_trait]
 pub trait Forge {
-    fn new() -> Self
-    where
-        Self: Sized;
-
     async fn get_flagship_host(&self) -> Result<String, ForgeError>;
 
     async fn get_api_releases_url(

--- a/src/api/v1/forges/auto_discover.rs
+++ b/src/api/v1/forges/auto_discover.rs
@@ -14,10 +14,10 @@ impl AutoDiscover {
     async fn try_autodiscovery_for(&self, host: &str) -> Result<DynForge, ForgeError> {
         if Forgejo::is_host_forgejo(host).await? {
             trace!("Forgejo discovered at {host}");
-            Ok(Arc::new(Forgejo::new()) as DynForge)
+            Ok(Arc::new(Forgejo) as DynForge)
         } else if Gitlab::is_host_gitlab(host).await? {
             trace!("Gitlab discovered at {host}");
-            Ok(Arc::new(Gitlab::new()) as DynForge)
+            Ok(Arc::new(Gitlab) as DynForge)
         } else {
             Err(ForgeError::AutodetectFailed(host.to_string()))
         }
@@ -26,10 +26,6 @@ impl AutoDiscover {
 
 #[axum::async_trait]
 impl Forge for AutoDiscover {
-    fn new() -> Self {
-        Self
-    }
-
     async fn get_flagship_host(&self) -> Result<String, ForgeError> {
         Err(ForgeError::NoFlagshipInstance)
     }

--- a/src/api/v1/forges/flakehub.rs
+++ b/src/api/v1/forges/flakehub.rs
@@ -11,10 +11,6 @@ pub struct FlakeHub;
 
 #[axum::async_trait]
 impl Forge for FlakeHub {
-    fn new() -> Self {
-        Self
-    }
-
     async fn get_flagship_host(&self) -> Result<String, ForgeError> {
         Ok("flakehub.com".to_string())
     }

--- a/src/api/v1/forges/forgejo.rs
+++ b/src/api/v1/forges/forgejo.rs
@@ -41,10 +41,6 @@ impl Forgejo {
 
 #[axum::async_trait]
 impl Forge for Forgejo {
-    fn new() -> Self {
-        Self
-    }
-
     async fn get_flagship_host(&self) -> Result<String, ForgeError> {
         Ok("codeberg.org".to_string())
     }

--- a/src/api/v1/forges/github.rs
+++ b/src/api/v1/forges/github.rs
@@ -11,10 +11,6 @@ pub struct GitHub;
 
 #[axum::async_trait]
 impl Forge for GitHub {
-    fn new() -> Self {
-        Self
-    }
-
     async fn get_flagship_host(&self) -> Result<String, ForgeError> {
         Ok("github.com".to_string())
     }

--- a/src/api/v1/forges/gitlab.rs
+++ b/src/api/v1/forges/gitlab.rs
@@ -45,10 +45,6 @@ impl Gitlab {
 
 #[axum::async_trait]
 impl Forge for Gitlab {
-    fn new() -> Self {
-        Self
-    }
-
     async fn get_flagship_host(&self) -> Result<String, ForgeError> {
         Err(ForgeError::NoFlagshipInstance)
     }

--- a/src/api/v1/forges/sourcehut.rs
+++ b/src/api/v1/forges/sourcehut.rs
@@ -26,10 +26,6 @@ impl SourceHut {
 
 #[axum::async_trait]
 impl Forge for SourceHut {
-    fn new() -> Self {
-        Self
-    }
-
     async fn get_flagship_host(&self) -> Result<String, ForgeError> {
         Ok("git.sr.ht".to_string())
     }

--- a/src/api/v1/routes.rs
+++ b/src/api/v1/routes.rs
@@ -4,38 +4,72 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use axum::Router;
+use axum::{extract::Extension, routing::get, Router};
 
-use super::{AutoDiscover, FlakeHub, Forge, Forgejo, GitHub, Gitlab, SourceHut};
+use super::forge;
+use super::{AutoDiscover, DynForge, FlakeHub, Forge, Forgejo, GitHub, Gitlab, SourceHut};
+use std::sync::Arc;
+
+fn get_forge_routes(forge: impl Forge + Send + Sync + 'static) -> Router {
+    let forge = Arc::new(forge) as DynForge;
+    Router::new()
+        .route(
+            "/:user/:repo",
+            get(forge::handlers::get_tarball_url_for_latest_release),
+        )
+        .route(
+            "/:user/:repo/branch/*branch",
+            get(forge::handlers::get_tarball_url_for_branch),
+        )
+        .route(
+            "/:user/:repo/b/*branch",
+            get(forge::handlers::get_tarball_url_for_branch),
+        )
+        .route(
+            "/:user/:repo/version/:version",
+            get(forge::handlers::get_tarball_url_for_version),
+        )
+        .route(
+            "/:user/:repo/v/:version",
+            get(forge::handlers::get_tarball_url_for_version),
+        )
+        .route(
+            "/:user/:repo/tag/:version",
+            get(forge::handlers::get_tarball_url_for_version),
+        )
+        .route(
+            "/:user/:repo/t/:version",
+            get(forge::handlers::get_tarball_url_for_version),
+        )
+        .layer(Extension(forge))
+}
+
+fn get_self_hosted_forge_routes(forge: impl Forge + Send + Sync + 'static) -> Router {
+    Router::new().nest("/:host", get_forge_routes(forge))
+}
 
 pub fn get_routes() -> Router {
-    let forgejo = Forgejo::new();
-    let github = GitHub::new();
-    let gitlab = Gitlab::new();
-    let flakehub = FlakeHub::new();
-    let sourcehut = SourceHut::new();
-
     Router::new()
         // --- Forgejo & Gitea
-        .nest("/forgejo", forgejo.get_self_hosted_routes())
-        .nest("/gitea", forgejo.get_self_hosted_routes())
-        .nest("/codeberg", forgejo.get_routes())
-        .nest("/codeberg.org", forgejo.get_routes())
+        .nest("/forgejo", get_self_hosted_forge_routes(Forgejo))
+        .nest("/gitea", get_self_hosted_forge_routes(Forgejo))
+        .nest("/codeberg", get_forge_routes(Forgejo))
+        .nest("/codeberg.org", get_forge_routes(Forgejo))
         // --- Gitlab
         // For Gitlab, we do not provide a flagship instance, because gitlab.com
         // is behind a login wall. Thus, gitlab.com must be explicitly
         // specified, as if it was self-hosted.
-        .nest("/gitlab", gitlab.get_self_hosted_routes())
+        .nest("/gitlab", get_self_hosted_forge_routes(Gitlab))
         // --- SourceHut
-        .nest("/sourcehut", sourcehut.get_self_hosted_routes())
-        .nest("/sr.ht", sourcehut.get_routes())
-        .nest("/git.sr.ht", sourcehut.get_routes())
+        .nest("/sourcehut", get_self_hosted_forge_routes(SourceHut))
+        .nest("/sr.ht", get_forge_routes(SourceHut))
+        .nest("/git.sr.ht", get_forge_routes(SourceHut))
         // --- GitHub
-        .nest("/github", github.get_routes())
-        .nest("/github.com", github.get_routes())
+        .nest("/github", get_forge_routes(GitHub))
+        .nest("/github.com", get_forge_routes(GitHub))
         // --- FlakeHub
-        .nest("/flakehub", flakehub.get_routes())
-        .nest("/flakehub.com", flakehub.get_routes())
+        .nest("/flakehub", get_forge_routes(FlakeHub))
+        .nest("/flakehub.com", get_forge_routes(FlakeHub))
         // --- Automatic discovery
-        .nest("/:host", AutoDiscover::new().get_routes())
+        .nest("/:host", get_forge_routes(AutoDiscover))
 }


### PR DESCRIPTION
There's no need to have the routing be part of the trait. It was only there for the sake of convenience, and we can achieve similar levels of convenience in ways that doesn't require routing in the trait itself.

Like simply lifting out the routing functions, and making them take an argument that implements the Forge trait (+ some others so we can turn it into a DynForge).

Builds on top of #30, but submitted separately, because #30 is already big. 90526b7fb2c2466c576a936b1d84c48d37d42592 and 83cfa3e27b244f8e44cba774f8538df8a5fb9718 are the commits thats actually matter.