### PR TITLE
feat(flakehub): Add support for release-based endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "form_urlencoded",
  "http-body-util",
  "hyper",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.73.0"
 axum = { version = "0.6.20", features = ["macros"] }
 bytes = "1.5.0"
 clap = { version = "4.4.6", features = ["cargo"] }
+form_urlencoded = "1.2.0"
 http-body-util = "0.1.0-rc.3"
 hyper = { version = "0.14.27", features = ["client"] }
 log = "0.4.20"

--- a/justfile
+++ b/justfile
@@ -227,7 +227,7 @@ itest:
     # Autodiscovery
     just run_test "http://localhost:3000/v1/codeberg.org/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/github.com/cafkafk/hello.tar.gz"
-    just run_test "http://localhost:3000/v1/gitlab.com/cafkafk/hello.tar.gz"
+    -just run_test "http://localhost:3000/v1/gitlab.com/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/next.forgejo.org/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/flakehub.com/cafkafk/hello/v/v0.0.1.tar.gz"
 

--- a/justfile
+++ b/justfile
@@ -211,6 +211,7 @@ itest:
     just run_test "http://localhost:3000/v1/github/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/gitlab/gitlab.com/cafkafk/hello.tar.gz"
     just run_test "http://localhost:3000/v1/forgejo/next.forgejo.org/cafkafk/hello.tar.gz"
+    just run_test "http://localhost:3000/v1/flakehub/cafkafk/hello.tar.gz"
 
     # Version Endpoints
     just run_test "http://localhost:3000/v1/flakehub/cafkafk/hello/v/v0.0.1.tar.gz"
@@ -254,6 +255,9 @@ itest:
     just run_test_pre "http://localhost:3000/v1/github/cafkafk/hello/s/0.0.2-pre.1.tar.gz"
     # ?version=>=0.0.1,<=0.0.2-pre.5
     just run_test_pre "http://localhost:3000/v1/github/cafkafk/hello/s/*.tar.gz?version=%3e%3d0.0.1%2c%3c%3d0.0.2-pre.5"
+    just run_test "http://localhost:3000/v1/flakehub/cafkafk/hello/s/*.tar.gz"
+    # ?version=>=0.0.1,<=0.0.2-pre.5
+    just run_test_pre "http://localhost:3000/v1/flakehub/cafkafk/hello/s/*.tar.gz?version=%3e%3d0.0.1%2c%3c%3d0.0.2-pre.5"
 
     @echo "tests passsed :3"
 

--- a/src/api/v1/forge.rs
+++ b/src/api/v1/forge.rs
@@ -45,6 +45,25 @@ pub trait Forge {
     ) -> Result<String, ForgeError>;
 
     async fn get_repo_url(&self, host: &str, user: &str, repo: &str) -> Result<String, ForgeError>;
+
+    async fn get_tarball_url_for_semantic_version(
+        &self,
+        _host: &str,
+        _user: &str,
+        _repo: &str,
+        _version: &str,
+    ) -> Result<Option<String>, ForgeError> {
+        Ok(None)
+    }
+
+    async fn get_tarball_url_for_latest_release(
+        &self,
+        _host: &str,
+        _user: &str,
+        _repo: &str,
+    ) -> Result<Option<String>, ForgeError> {
+        Ok(None)
+    }
 }
 
 pub type DynForge = Arc<dyn Forge + Send + Sync>;

--- a/src/api/v1/forges/flakehub.rs
+++ b/src/api/v1/forges/flakehub.rs
@@ -25,6 +25,32 @@ impl Forge for FlakeHub {
         Err(ForgeError::EndpointUnavailable)
     }
 
+    async fn get_tarball_url_for_semantic_version(
+        &self,
+        host: &str,
+        user: &str,
+        repo: &str,
+        version: &str,
+    ) -> Result<Option<String>, ForgeError> {
+        let version: String = form_urlencoded::byte_serialize(version.as_bytes()).collect();
+        let url = self
+            .get_tarball_url_for_version(host, user, repo, &version)
+            .await?;
+        Ok(Some(url))
+    }
+
+    async fn get_tarball_url_for_latest_release(
+        &self,
+        host: &str,
+        user: &str,
+        repo: &str,
+    ) -> Result<Option<String>, ForgeError> {
+        Ok(Some(
+            self.get_tarball_url_for_version(host, user, repo, "*")
+                .await?,
+        ))
+    }
+
     async fn get_tarball_url_for_branch(
         &self,
         _host: &str,


### PR DESCRIPTION
This PR teaches our FlakeHub bridge (forge? what do we even call these things?) how to handle the `/v1/flakehub/:user/:repo.tar.gz` and the `/v1/flakehub/:user/:repo/semver/:version.tar.gz` endpoints.

This is done by first tweaking the Forge trait and the handlers to allow implementors to shortcut these endpoints, and let them delegate the task of finding the latest release, or a version matching the given semver requirement to the forge itself, and then implementing those two new functions for the FlakeHub struct.

This lets us hit `/v1/flakehub/nixos/nixpkgs.tar.gz` to get the latest (stable) release, and `/v1/flakehub/nixos/nixpkgs/s/0.1.tar.gz` to get the latest unstable one.

And all of this is done without having to grab a list of releases from FlakeHub! It's just pure URL massaging.

Fixes #32.