### PR TITLE
refactor(handlers): Lift out a sizeable amount of shared code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.73.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "0.6.20", features = ["macros"] }
+axum = { version = "0.6.20", features = ["macros", "original-uri"] }
 bytes = "1.5.0"
 clap = { version = "4.4.6", features = ["cargo"] }
 form_urlencoded = "1.2.0"

--- a/src/api/v1/forge.rs
+++ b/src/api/v1/forge.rs
@@ -14,7 +14,7 @@ mod error;
 pub use error::ForgeError;
 pub mod handlers;
 mod releases;
-pub use releases::ForgeReleases;
+pub use releases::{ForgeRelease, ForgeReleases};
 
 #[async_trait]
 pub trait Forge {

--- a/src/api/v1/forge/error.rs
+++ b/src/api/v1/forge/error.rs
@@ -20,6 +20,7 @@ pub enum ForgeError {
     SemverError(semver::Error),
     BadRequest(String),
     NoTarGz(String),
+    NoReleaseFound(String),
 }
 
 impl IntoResponse for ForgeError {
@@ -67,6 +68,10 @@ impl IntoResponse for ForgeError {
                     "Hi friend, you probably meant to request {}.tar.gz, that should work <3",
                     uri
                 ),
+            ),
+            ForgeError::NoReleaseFound(repo) => (
+                StatusCode::NOT_FOUND,
+                format!("Hi friend, no suitable releases found for {} :(", repo),
             ),
         };
         (status, error_message).into_response()

--- a/src/api/v1/forge/error.rs
+++ b/src/api/v1/forge/error.rs
@@ -19,6 +19,7 @@ pub enum ForgeError {
     AutodetectFailed(String),
     SemverError(semver::Error),
     BadRequest(String),
+    NoTarGz(String),
 }
 
 impl IntoResponse for ForgeError {
@@ -60,6 +61,13 @@ impl IntoResponse for ForgeError {
                 error!("ForgeError::BadRequest: {error}");
                 (StatusCode::BAD_REQUEST, error)
             }
+            ForgeError::NoTarGz(uri) => (
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "Hi friend, you probably meant to request {}.tar.gz, that should work <3",
+                    uri
+                ),
+            ),
         };
         (status, error_message).into_response()
     }

--- a/src/api/v1/forge/handlers.rs
+++ b/src/api/v1/forge/handlers.rs
@@ -33,6 +33,17 @@ async fn get_host_user_repo_triplet(
     Ok((host, user, repo))
 }
 
+fn try_strip_targz_suffix(part: &str, uri: &str) -> Result<String, ForgeError> {
+    if part.ends_with(".tar.gz") {
+        Ok(part
+            .strip_suffix(".tar.gz")
+            .expect("couldn't strip .tar.gz suffix")
+            .to_string())
+    } else {
+        Err(ForgeError::NoTarGz(uri.to_string()))
+    }
+}
+
 pub async fn get_tarball_url_for_latest_release(
     Path(paths): Path<HashMap<String, String>>,
     Extension(forge): Extension<DynForge>,
@@ -41,51 +52,37 @@ pub async fn get_tarball_url_for_latest_release(
     request: Request<Body>,
 ) -> Result<Response, ForgeError> {
     let (host, user, repo) = get_host_user_repo_triplet(&paths, &forge).await?;
+    let repo = try_strip_targz_suffix(&repo, &request.uri().to_string())?;
 
-    if repo.ends_with(".tar.gz") {
-        let repo_name = repo
-            .clone()
-            .strip_suffix(".tar.gz")
-            .expect("couldn't strip .tar.gz suffix")
-            .to_string();
+    if let Some(redirect_url) = forge
+        .get_tarball_url_for_latest_release(&host, &user, &repo)
+        .await?
+    {
+        trace!("tarball_url_for_latest_release: {redirect_url}");
+        Ok(Redirect::to(&redirect_url).into_response())
+    } else {
+        let api_releases_url = forge
+            .get_api_releases_url(&host, &user, &repo, config.get_forge_api_page_size())
+            .await?;
+        trace!("api_releases_url: {}", api_releases_url);
+        let releases = ForgeReleases::from_url(api_releases_url).await?;
 
-        if let Some(redirect_url) = forge
-            .get_tarball_url_for_latest_release(&host, &user, &repo_name)
-            .await?
-        {
-            trace!("tarball_url_for_latest_release: {redirect_url}");
+        if let Some(latest_release) = releases.latest_release(params.include_prereleases()) {
+            let latest_tag = latest_release.tag_name;
+            trace!("latest_tag: {latest_tag:}");
+
+            let redirect_url = forge
+                .get_tarball_url_for_version(&host, &user, &repo, &latest_tag)
+                .await?;
+            trace!("tarball_url_for_latest_release: {redirect_url:}");
             Ok(Redirect::to(&redirect_url).into_response())
         } else {
-            let api_releases_url = forge
-                .get_api_releases_url(&host, &user, &repo_name, config.get_forge_api_page_size())
-                .await?;
-            trace!("api_releases_url: {}", api_releases_url);
-            let releases = ForgeReleases::from_url(api_releases_url).await?;
-
-            if let Some(latest_release) = releases.latest_release(params.include_prereleases()) {
-                let latest_tag = latest_release.tag_name;
-                trace!("latest_tag: {latest_tag:}");
-
-                let redirect_url = forge
-                    .get_tarball_url_for_version(&host, &user, &repo_name, &latest_tag)
-                    .await?;
-                trace!("tarball_url_for_latest_release: {redirect_url:}");
-                Ok(Redirect::to(&redirect_url).into_response())
-            } else {
-                let body = format!(
-                    "Hi friend, no releases found for {} :(",
-                    forge.get_repo_url(&host, &user, &repo_name).await?
-                );
-                Ok((StatusCode::NOT_FOUND, body).into_response())
-            }
+            let body = format!(
+                "Hi friend, no releases found for {} :(",
+                forge.get_repo_url(&host, &user, &repo).await?
+            );
+            Ok((StatusCode::NOT_FOUND, body).into_response())
         }
-    } else {
-        let body = format!(
-            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
-            request.headers()["host"],
-            request.uri()
-        );
-        Ok((StatusCode::BAD_REQUEST, body).into_response())
     }
 }
 
@@ -102,7 +99,7 @@ pub async fn get_tarball_url_for_semantic_version(
     request: Request<Body>,
 ) -> Result<Response, ForgeError> {
     let (host, user, repo) = get_host_user_repo_triplet(&paths, &forge).await?;
-    let ver = if let Some(version) = &params.version {
+    let version = if let Some(version) = &params.version {
         format!("{version}.tar.gz")
     } else if let Some(version) = &paths.get("version") {
         version.to_string()
@@ -111,53 +108,39 @@ pub async fn get_tarball_url_for_semantic_version(
             "No semantic version requirement specified".to_string(),
         ));
     };
+    let version = try_strip_targz_suffix(&version, &request.uri().to_string())?;
 
-    if ver.ends_with(".tar.gz") {
-        let ver_name = ver
-            .clone()
-            .strip_suffix(".tar.gz")
-            .expect("couldn't strip .tar.gz suffix")
-            .to_string();
-
-        if let Some(semver_url) = forge
-            .get_tarball_url_for_semantic_version(&host, &user, &repo, &ver_name)
-            .await?
-        {
-            trace!("tarball_url_for_semantic_version: {semver_url}");
-            Ok(Redirect::to(&semver_url).into_response())
-        } else {
-            let api_releases_url = forge
-                .get_api_releases_url(&host, &user, &repo, config.get_forge_api_page_size())
-                .await?;
-            trace!("api_releases_url: {}", api_releases_url);
-            let releases = ForgeReleases::from_url(api_releases_url).await?;
-
-            let v = semver::VersionReq::parse(&ver_name)?;
-
-            if let Some(latest_release) = releases.matching(&repo, v) {
-                let latest_tag = latest_release.tag_name;
-                trace!("latest_tag: {latest_tag:}");
-
-                let redirect_url = forge
-                    .get_tarball_url_for_version(&host, &user, &repo, &latest_tag)
-                    .await?;
-                trace!("tarball_url_for_latest_release: {redirect_url:}");
-                Ok(Redirect::to(&redirect_url).into_response())
-            } else {
-                let body = format!(
-                    "Hi friend, no releases found for {} :(",
-                    forge.get_repo_url(&host, &user, &repo).await?
-                );
-                Ok((StatusCode::NOT_FOUND, body).into_response())
-            }
-        }
+    if let Some(semver_url) = forge
+        .get_tarball_url_for_semantic_version(&host, &user, &repo, &version)
+        .await?
+    {
+        trace!("tarball_url_for_semantic_version: {semver_url}");
+        Ok(Redirect::to(&semver_url).into_response())
     } else {
-        let body = format!(
-            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
-            request.headers()["host"],
-            request.uri()
-        );
-        Ok((StatusCode::BAD_REQUEST, body).into_response())
+        let api_releases_url = forge
+            .get_api_releases_url(&host, &user, &repo, config.get_forge_api_page_size())
+            .await?;
+        trace!("api_releases_url: {}", api_releases_url);
+        let releases = ForgeReleases::from_url(api_releases_url).await?;
+
+        let v = semver::VersionReq::parse(&version)?;
+
+        if let Some(latest_release) = releases.matching(&repo, v) {
+            let latest_tag = latest_release.tag_name;
+            trace!("latest_tag: {latest_tag:}");
+
+            let redirect_url = forge
+                .get_tarball_url_for_version(&host, &user, &repo, &latest_tag)
+                .await?;
+            trace!("tarball_url_for_latest_release: {redirect_url:}");
+            Ok(Redirect::to(&redirect_url).into_response())
+        } else {
+            let body = format!(
+                "Hi friend, no releases found for {} :(",
+                forge.get_repo_url(&host, &user, &repo).await?
+            );
+            Ok((StatusCode::NOT_FOUND, body).into_response())
+        }
     }
 }
 
@@ -167,29 +150,12 @@ pub async fn get_tarball_url_for_branch(
     request: Request<Body>,
 ) -> Result<Response, ForgeError> {
     let (host, user, repo) = get_host_user_repo_triplet(&paths, &forge).await?;
-    let branch = &paths["branch"];
-
-    if branch.ends_with(".tar.gz") {
-        let url = forge
-            .get_tarball_url_for_branch(
-                &host,
-                &user,
-                &repo,
-                branch
-                    .strip_suffix(".tar.gz")
-                    .expect("couldn't strip .tar.gz suffix"),
-            )
-            .await?;
-        trace!("tarball_url_for_branch: {url:}");
-        Ok(Redirect::to(&url).into_response())
-    } else {
-        let body = format!(
-            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
-            request.headers()["host"],
-            request.uri()
-        );
-        Ok((StatusCode::BAD_REQUEST, body).into_response())
-    }
+    let branch = try_strip_targz_suffix(&paths["branch"], &request.uri().to_string())?;
+    let url = forge
+        .get_tarball_url_for_branch(&host, &user, &repo, &branch)
+        .await?;
+    trace!("tarball_url_for_branch: {url:}");
+    Ok(Redirect::to(&url).into_response())
 }
 
 pub async fn get_tarball_url_for_version(
@@ -198,27 +164,10 @@ pub async fn get_tarball_url_for_version(
     request: Request<Body>,
 ) -> Result<Response, ForgeError> {
     let (host, user, repo) = get_host_user_repo_triplet(&paths, &forge).await?;
-    let version = &paths["version"];
-
-    if version.ends_with(".tar.gz") {
-        let url = forge
-            .get_tarball_url_for_version(
-                &host,
-                &user,
-                &repo,
-                version
-                    .strip_suffix(".tar.gz")
-                    .expect("couldn't strip .tar.gz suffix"),
-            )
-            .await?;
-        trace!("tarball_url_for_version: {url:}");
-        Ok(Redirect::to(&url).into_response())
-    } else {
-        let body = format!(
-            "Hi friend, you probably meant to request {:#?}{}.tar.gz, that should work <3",
-            request.headers()["host"],
-            request.uri()
-        );
-        Ok((StatusCode::BAD_REQUEST, body).into_response())
-    }
+    let version = try_strip_targz_suffix(&paths["version"], &request.uri().to_string())?;
+    let url = forge
+        .get_tarball_url_for_version(&host, &user, &repo, &version)
+        .await?;
+    trace!("tarball_url_for_version: {url:}");
+    Ok(Redirect::to(&url).into_response())
 }


### PR DESCRIPTION
These patches lift out some common patterns in the handlers, so we have far less repetition in there: first, I lift out the part that checks for a `.tar.gz` suffix, removing plenty of copies of the same code, and also reducing the level of indentation by one! Then, I lift out code common to both `get_tarball_url_for_latest_release()` and `get_tarball_url_for_semantic_version()`, removing only two copies, but it's a sizeable amount of copy pasta removed nevertheless, and another level of indentation.

As an added side effect, it updates the message we report when the `.tar.gz` suffix is missing: it now correctly displays the full uri again. When we moved to nested routes, the uri displayed there broke, because it only displayed the innermost part of the captured path. Now it displays the full one - but not the host, mind you (but the host display was kinda borked anyway, as it had quotes, while the rest of the url did not). Adding that back, and possibly the scheme too, wouldn't be too hard.