### PR TITLE
feat(forge): try extracting a semver more aggressively

### DIFF
--- a/src/api/v1/forge/handlers.rs
+++ b/src/api/v1/forge/handlers.rs
@@ -138,7 +138,7 @@ pub async fn get_tarball_url_for_semantic_version(
         &user,
         &repo,
         config.get_forge_api_page_size(),
-        |releases| releases.matching(&repo, v),
+        |releases| releases.matching(v),
     )
     .await?;
     trace!("tarball_url_for_semantic_version: {redirect_url}");

--- a/src/api/v1/forge/releases.rs
+++ b/src/api/v1/forge/releases.rs
@@ -57,25 +57,19 @@ impl ForgeReleases {
         }
     }
 
-    fn try_version_from_tag(&self, repo: &str, ver: &str) -> Result<semver::Version, ForgeError> {
-        // v<ver> => <repo>- => <ver>
-        let v = if ver.starts_with('v') {
-            ver.strip_prefix('v')
-                .expect("couldn't strip the `v` prefix")
-        } else if ver.starts_with(&format!("{repo}-")) {
-            ver.strip_prefix(&format!("{repo}-"))
-                .expect("couldn't strip the `{repo}-` prefix")
-        } else {
-            ver
-        };
-
-        Ok(semver::Version::parse(v)?)
+    fn try_version_from_tag(&self, ver: &str) -> Result<semver::Version, ForgeError> {
+        let semver = ver.char_indices().find_map(|(i, _)| {
+            let substr = &ver[i..];
+            let v = semver::Version::parse(substr);
+            v.map_or(None, |_| Some(substr))
+        });
+        Ok(semver::Version::parse(semver.map_or(ver, |s| s))?)
     }
 
-    pub fn matching(self, repo: &str, version_req: semver::VersionReq) -> Option<ForgeRelease> {
+    pub fn matching(self, version_req: semver::VersionReq) -> Option<ForgeRelease> {
         self.0.clone().into_iter().find(|v| {
             trace!("trying to match {} against {}", &v.tag_name, version_req);
-            match self.try_version_from_tag(repo, &v.tag_name) {
+            match self.try_version_from_tag(&v.tag_name) {
                 Ok(version) => version_req.matches(&version),
                 _ => false,
             }


### PR DESCRIPTION
When trying to extract a semantic version from a tag name, do so more aggressively: try parsing its slices, starting from the beginning, and stop as soon as a semantic version is found. If none are found, return an error.

This replaces the former special casing of the `v` and `{repo}-` prefixes. While the new method is a little less efficient, it's not terribly so, but it is far more flexible.