### PR TITLE
refactor(forge): Make ForgeReleases.matching more functional

### DIFF
--- a/src/api/v1/forge/releases.rs
+++ b/src/api/v1/forge/releases.rs
@@ -69,10 +69,8 @@ impl ForgeReleases {
     pub fn matching(self, version_req: semver::VersionReq) -> Option<ForgeRelease> {
         self.0.clone().into_iter().find(|v| {
             trace!("trying to match {} against {}", &v.tag_name, version_req);
-            match self.try_version_from_tag(&v.tag_name) {
-                Ok(version) => version_req.matches(&version),
-                _ => false,
-            }
+            self.try_version_from_tag(&v.tag_name)
+                .map_or(false, |v| version_req.matches(&v))
         })
     }
 


### PR DESCRIPTION
Rather than doing a match on a Result, in `ForgeReleases.matching()`, use `.map_or()` instead: its more succinct, and conveys the intent better.

(Built on top of #43, so that it'll be easier to rebase)